### PR TITLE
bugfix/missing-comma-was-creating-a-new-file-format

### DIFF
--- a/bioio_imageio/reader_metadata.py
+++ b/bioio_imageio/reader_metadata.py
@@ -77,7 +77,8 @@ class ReaderMetadata(bioio_base.reader_metadata.ReaderMetadata):
             "mpo",
             "msp",
             "pdf",
-            "png" "ppm",
+            "png",
+            "ppm",
             "ps",
             "zif",
         ]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->


### Description of Changes

<!-- Include a description of the proposed changes. -->

Found while working on napari stuff which tests for `png` support. If you try to read a PNG directly with this package's `Reader`, it works! If you try to read a PNG with `BioImage`, it fails because it doesn't have a plugin listing for `"png"` but does have one for `"pngppm"` because if there isn't a comma, Python will combine strings together 🙃🙃🙃.