### PR TITLE
Feature/share ci lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
   # Shared lint workflow from bioio-base
   lint:
     uses: bioio-devs/bioio-base/.github/workflows/shared_lint.yml@main
-    with:
-      lint_python_version: "3.11"
   
   # Shared test workflow from bioio-base
   test:

--- a/bioio_imageio/metadata_utils.py
+++ b/bioio_imageio/metadata_utils.py
@@ -17,7 +17,7 @@ def generate_ome_image_id(image_id: Union[str, int]) -> str:
     ome_image_id: str
         The OME standard for image IDs.
     """
-    return f"Image:{image_id}"
+    return f"Image: {image_id}"
 
 
 def generate_ome_channel_id(image_id: str, channel_id: Union[str, int]) -> str:
@@ -47,4 +47,4 @@ def generate_ome_channel_id(image_id: str, channel_id: Union[str, int]) -> str:
     """
     # Remove the prefix 'Image:' to get just the index
     image_index = image_id.replace("Image:", "")
-    return f"Channel:{image_index}:{channel_id}"
+    return f"Channel:{image_index}:{channel_id}"  # noqa: E231

--- a/bioio_imageio/metadata_utils.py
+++ b/bioio_imageio/metadata_utils.py
@@ -17,7 +17,7 @@ def generate_ome_image_id(image_id: Union[str, int]) -> str:
     ome_image_id: str
         The OME standard for image IDs.
     """
-    return f"Image: {image_id}"
+    return f"Image:{image_id}"  # noqa: E231
 
 
 def generate_ome_channel_id(image_id: str, channel_id: Union[str, int]) -> str:


### PR DESCRIPTION
Remove the lint version specification parameter.  Add noqa tags to allow passing lint for python 3.13
relevant to https://github.com/bioio-devs/bioio-base/issues/55