### PR TITLE
Feature/share ci ffmpeg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     uses: bioio-devs/bioio-base/.github/workflows/shared_test.yml@main
     with:
       test_checkout_lfs: true
-      install_ffmpeg_macos: true
+      install_ffmpeg_macos: false
 
   # Check package performance
   benchmark:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
     uses: bioio-devs/bioio-base/.github/workflows/shared_test.yml@main
     with:
       test_checkout_lfs: true
-      install_ffmpeg_macos: false
 
   # Check package performance
   benchmark:


### PR DESCRIPTION
Remove the unneeded reference to ffmpeg

### Link to Relevant Issue

https://github.com/bioio-devs/bioio-base/issues/55 , phase two reducing the parameters

### Description of Changes

No longer invoke the distinct ffmpeg install, since it is in the requirements
